### PR TITLE
Make icons slottable in buttons

### DIFF
--- a/src/components/elements/button.svelte
+++ b/src/components/elements/button.svelte
@@ -2,8 +2,6 @@
     import {createEventDispatcher, getContext} from 'svelte'
     import {spring} from 'svelte/motion'
 
-    import Icon from '~/components/elements/icon.svelte'
-
     /** If set button will act as a standard <a href=..tag. */
     export let href: string | undefined = undefined
     /** Whether the button is primary. */
@@ -14,10 +12,6 @@
     export let disabled: boolean = false
     /** Type of button */
     export let formValidation: boolean = false
-    /** Icon within the button */
-    export let icon: string | undefined = undefined
-    /** Icon position, left or right */
-    export let iconPosition: string = 'right'
 
     // Get parent form disabled state (if exists)
     const formDisabled: SvelteStore<boolean> = getContext('formDisabled')
@@ -65,8 +59,11 @@
 </script>
 
 <style type="scss">
-    $radius: 8px;
     .button {
+        --spacing: 4px; // between items in button
+        --radius: 8px; // corner radius of button
+        --gradient-size: 200px; // size of hover effect
+
         position: relative;
         font-size: 10px;
         display: inline-flex;
@@ -74,12 +71,15 @@
         letter-spacing: 0.1px;
         justify-content: center;
         background-color: var(--light-blue);
-        border-radius: $radius;
+        border-radius: var(--radius);
         padding: 10px 12px;
         color: var(--main-blue);
         user-select: none;
         -webkit-user-select: none;
         cursor: pointer;
+        overflow: hidden;
+        white-space: nowrap;
+
         &.primary {
             background-color: var(--main-blue);
             color: white;
@@ -110,15 +110,13 @@
         :global(*) {
             pointer-events: none;
         }
-
         .hover {
-            --gradient-size: 200px;
             position: absolute;
             transition: 140ms ease-in-out;
             transition-property: width, left, opacity;
             top: calc(var(--gradient-size) / -2);
             left: 0px;
-            border-radius: $radius;
+            border-radius: var(--radius);
             background: radial-gradient(circle closest-side, white, transparent);
             width: 0px;
             height: var(--gradient-size);
@@ -129,23 +127,20 @@
             width: var(--gradient-size);
             left: calc(var(--gradient-size) / -2);
         }
-        overflow: hidden;
         .content {
+            z-index: 1;
             display: flex;
             flex-direction: row;
             align-items: center;
-            z-index: 1;
-            &.icon-left {
-                flex-direction: row-reverse;
-                .text {
-                    margin-left: 0.625em;
-                }
-            }
-            .text {
-                margin-right: 0.625em;
-            }
+        }
+        :global(.content > *) {
+            margin-right: var(--spacing);
+        }
+        :global(.content > *:last-child) {
+            margin-right: 0;
         }
         &.size-large {
+            --spacing: 8px;
             .hover {
                 --gradient-size: 500px;
             }
@@ -170,14 +165,7 @@
     tabindex="0"
 >
     <span class="hover" style={`transform: translate(${$hoverPos.x}px, ${$hoverPos.y}px)`} />
-    <span class={`content icon-${iconPosition}`}>
-        <span class="text">
-            <slot>Click me</slot>
-        </span>
-        {#if icon}
-            <span class="icon">
-                <Icon name={icon} />
-            </span>
-        {/if}
+    <span class="content">
+        <slot>Click me</slot>
     </span>
 </a>

--- a/src/components/elements/icon.svelte
+++ b/src/components/elements/icon.svelte
@@ -1,50 +1,53 @@
+<script context="module" lang="ts">
+    export type IconSize = 'tiny' | 'small' | 'regular' | 'medium' | 'large' | 'huge' | 'massive'
+</script>
+
 <script lang="ts">
     import {icons} from 'feather-icons'
 
     export let name = 'help-circle'
-    export let dimensions = '1em'
-    export let size = 'default'
+    export let size: IconSize = 'regular'
 
     if (!icons[name]) {
         name = 'help-circle'
     }
-
-    switch (size) {
-        case 'tiny': {
-            dimensions = '0.5em'
-            break
-        }
-        case 'small': {
-            dimensions = '0.75em'
-            break
-        }
-        case 'default': {
-            dimensions = '1em'
-            break
-        }
-        case 'medium': {
-            dimensions = '1.25em'
-            break
-        }
-        case 'large': {
-            dimensions = '1.5em'
-            break
-        }
-        case 'huge': {
-            dimensions = '2.5em'
-            break
-        }
-        case 'massive': {
-            dimensions = '4em'
-            break
-        }
-    }
 </script>
 
 <style type="scss">
+    .icon {
+        --size: 1em;
+
+        display: inline-flex;
+        width: var(--size);
+        height: var(--size);
+
+        :global(svg) {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+
+        &.tiny {
+            --size: 0.5em;
+        }
+        &.small {
+            --size: 0.75em;
+        }
+        &.medium {
+            --size: 1.25em;
+        }
+        &.large {
+            --size: 1.5em;
+        }
+        &.huge {
+            --size: 2.5em;
+        }
+        &.massive {
+            --size: 4em;
+        }
+    }
 </style>
 
-{@html icons[name].toSvg({
-    height: dimensions,
-    width: dimensions,
-})}
+<span class={`icon ${size}`}>
+    {@html icons[name].toSvg()}
+</span>

--- a/src/components/elements/text.svelte
+++ b/src/components/elements/text.svelte
@@ -1,0 +1,2 @@
+<!-- This exists because text nodes cannot be targeted by css selectors and we want the flexbox layout system to be consistent. -->
+<span class="text"><slot>Text</slot></span>

--- a/src/pages/_components/buttons.svelte
+++ b/src/pages/_components/buttons.svelte
@@ -1,5 +1,7 @@
 <script>
     import Button from '~/components/elements/button.svelte'
+    import Icon from '~/components/elements/icon.svelte'
+    import Text from '~/components/elements/text.svelte'
 </script>
 
 <style lang="scss">
@@ -20,20 +22,50 @@
 <div>
     <Button>Standard</Button>
     <Button primary>Primary</Button>
-    <Button icon="external-link">Icon</Button>
-    <Button icon="external-link" iconPosition="left">Icon left</Button>
+    <Button>
+        <Text>Icon</Text>
+        <Icon name="external-link" />
+    </Button>
+    <Button>
+        <Icon name="external-link" />
+        <Text>Icon left</Text>
+    </Button>
 </div>
 
 <div>
     <Button size="large">Large</Button>
     <Button size="large" primary>Large Primary</Button>
-    <Button size="large" icon="external-link">Large with icon</Button>
-    <Button size="large" icon="external-link" iconPosition="left">Large with icon left</Button>
+    <Button size="large">
+        <Icon name="unlock" />
+        <Text>Icon here</Text>
+    </Button>
+    <Button size="large">
+        <Text>Icon there</Text>
+        <Icon name="external-link" />
+    </Button>
+    <Button size="large">
+        <Icon name="bell" />
+        <Text>Icon</Text>
+        <Icon name="activity" />
+        <Text>everywhere</Text>
+        <Icon name="octagon" />
+    </Button>
 </div>
 
 <div class="overunder">
     <Button size="large">Flexy</Button>
     <Button size="large" primary>Flexy Primary</Button>
-    <Button size="large" primary icon="layout">Flexy with icon</Button>
-    <Button size="large" primary icon="layout" iconPosition="left">Flexy with icon left</Button>
+    <Button size="large" primary>
+        <Icon name="layout" />
+        <Text>Flexy with icon</Text>
+    </Button>
+    <Button size="large" primary>
+        <Icon name="tool" />
+        <Text>Flexing</Text>
+        <Icon name="trash" />
+        <Text>my</Text>
+        <Icon name="layout" />
+        <Text>icons</Text>
+        <Icon name="twitter" />
+    </Button>
 </div>

--- a/src/pages/_components/icons.svelte
+++ b/src/pages/_components/icons.svelte
@@ -11,7 +11,7 @@
     <p>small</p>
     <Icon name="anchor" size="small" />
     <p>default</p>
-    <Icon name="anchor" size="default" />
+    <Icon name="anchor" />
     <p>medium</p>
     <Icon name="anchor" size="medium" />
     <p>large</p>


### PR DESCRIPTION
Allows icons to be slotted in buttons as any other element

Also introduces the a `Text` element that should be used in buttons (and other flexbox containers with slots) when you want to mix text and other elements.