### PR TITLE
fix net price for powerup and stake

### DIFF
--- a/src/pages/earn/step/bootstrap.svelte
+++ b/src/pages/earn/step/bootstrap.svelte
@@ -7,7 +7,7 @@
     import Form from '~/components/elements/form.svelte'
     import InputAsset from '~/components/elements/input/asset.svelte'
     import InputLabel from '~/components/elements/input/label.svelte'
-    import {REXInfo} from '../types'
+    import type {REXInfo} from '../types'
 
     export let amount: string
     export let availableTokens: Asset

--- a/src/pages/resources/components/forms/powerup.svelte
+++ b/src/pages/resources/components/forms/powerup.svelte
@@ -9,7 +9,12 @@
     import {activeBlockchain, activeSession, currentAccount} from '~/store'
     import {systemToken} from '~/stores/tokens'
     import {systemTokenBalance} from '~/stores/balances'
-    import {powerupPrice, sampleUsage, statePowerUp} from '~/pages/resources/resources'
+    import {
+        cpuPowerupPrice,
+        netPowerupPrice,
+        sampleUsage,
+        statePowerUp,
+    } from '~/pages/resources/resources'
 
     import type {FormTransaction} from '~/ui-types'
     import Button from '~/components/elements/button.svelte'
@@ -23,6 +28,7 @@
 
     export let resource: string = 'cpu'
     const unit = resource === 'cpu' ? 'ms' : 'kb'
+    const powerupPrice = resource === 'cpu' ? cpuPowerupPrice : netPowerupPrice
 
     let amount: Writable<string> = writable('')
     let error: string | undefined

--- a/src/pages/resources/components/forms/rex.svelte
+++ b/src/pages/resources/components/forms/rex.svelte
@@ -10,7 +10,7 @@
     import {activeBlockchain, activeSession, currentAccount} from '~/store'
     import {systemToken} from '~/stores/tokens'
     import {systemTokenBalance} from '~/stores/balances'
-    import {rexPrice} from '~/pages/resources/resources'
+    import {cpuRexPrice, netRexPrice} from '~/pages/resources/resources'
 
     import type {FormTransaction} from '~/ui-types'
     import Button from '~/components/elements/button.svelte'
@@ -24,6 +24,7 @@
 
     export let resource = 'cpu'
     const unit = resource === 'cpu' ? 'ms' : 'kb'
+    const rexPrice = resource === 'cpu' ? cpuRexPrice : netRexPrice
 
     let amount: Writable<string> = writable('')
     let error: string | undefined
@@ -41,6 +42,10 @@
             }
         }
     )
+
+    const disabled: Readable<boolean> = derived(cost, ($cost) => {
+        return $cost ? $cost.value <= 0 : true
+    })
 
     // Create a derived store of the field we expect to be modified
     export const field = derived([currentAccount], ([$currentAccount]) => {
@@ -142,7 +147,7 @@
                 <FormBalance token={$systemToken} balance={systemTokenBalance} />
             {/if}
             <InputErrorMessage errorMessage={error} />
-            <Button fluid size="large" formValidation on:action={rex}
+            <Button fluid disabled={$disabled} size="large" formValidation on:action={rex}
                 >Rent {Number($amount)} {unit} for {$cost}</Button
             >
         </Form>

--- a/src/pages/resources/components/state/prices.svelte
+++ b/src/pages/resources/components/state/prices.svelte
@@ -5,7 +5,13 @@
     import {ChainFeatures} from '~/config'
     import {activeBlockchain} from '~/store'
 
-    import {powerupPrice, rexPrice, stakingPrice} from '~/pages/resources/resources'
+    import {
+        cpuPowerupPrice,
+        netPowerupPrice,
+        rexPrice,
+        cpuStakingPrice,
+        netStakingPrice,
+    } from '~/pages/resources/resources'
 
     import Button from '~/components/elements/button.svelte'
     import Segment from '~/components/elements/segment.svelte'
@@ -13,6 +19,8 @@
 
     export let resource = 'cpu'
     const unit = resource === 'cpu' ? 'ms' : 'kb'
+    const powerupPrice = resource === 'cpu' ? cpuPowerupPrice : netPowerupPrice
+    const stakingPrice = resource === 'cpu' ? cpuStakingPrice : netStakingPrice
 
     const {PowerUp, REX, Staking} = ChainFeatures
 
@@ -156,9 +164,7 @@
                 <div class="offer">
                     <div class="service">Staking</div>
                     <div class="price">
-                        {(Number($stakingPrice.value) * 1000).toFixed(
-                            $stakingPrice.symbol.precision
-                        )}
+                        {$stakingPrice.value.toFixed($stakingPrice.symbol.precision)}
                     </div>
                     <div class="pair">
                         {$token} per

--- a/src/pages/resources/components/state/prices.svelte
+++ b/src/pages/resources/components/state/prices.svelte
@@ -8,7 +8,8 @@
     import {
         cpuPowerupPrice,
         netPowerupPrice,
-        rexPrice,
+        cpuRexPrice,
+        netRexPrice,
         cpuStakingPrice,
         netStakingPrice,
     } from '~/pages/resources/resources'
@@ -21,6 +22,7 @@
     const unit = resource === 'cpu' ? 'ms' : 'kb'
     const powerupPrice = resource === 'cpu' ? cpuPowerupPrice : netPowerupPrice
     const stakingPrice = resource === 'cpu' ? cpuStakingPrice : netStakingPrice
+    const rexPrice = resource === 'cpu' ? cpuRexPrice : netRexPrice
 
     const {PowerUp, REX, Staking} = ChainFeatures
 

--- a/src/pages/resources/resources.ts
+++ b/src/pages/resources/resources.ts
@@ -1,14 +1,14 @@
-import {derived, Readable} from 'svelte/store'
-import {API, Asset} from '@greymass/eosio'
-import {Resources, SampleUsage, PowerUpState, RAMState, REXState} from '@greymass/eosio-resources'
-import {activeBlockchain} from '~/store'
+import { derived, Readable } from 'svelte/store'
+import { Int64, API, Asset } from '@greymass/eosio'
+import { Resources, SampleUsage, PowerUpState, RAMState, REXState } from '@greymass/eosio-resources'
+import { activeBlockchain } from '~/store'
 
-import {getClient} from '../../api-client'
-import {ChainConfig, ChainFeatures, resourceFeatures} from '~/config'
+import { getClient } from '../../api-client'
+import { ChainConfig, ChainFeatures, resourceFeatures } from '~/config'
 
 const getResourceClient = (chain: ChainConfig) => {
     const api = getClient(chain)
-    const options: any = {api}
+    const options: any = { api }
     if (chain.resourceSampleAccount) {
         options.sampleAccount = chain.resourceSampleAccount
     }
@@ -96,7 +96,8 @@ export const msToRent: Readable<number> = derived(activeBlockchain, ($activeBloc
     return 1
 })
 
-export const powerupPrice = derived(
+//price per ms
+export const cpuPowerupPrice = derived(
     [msToRent, sampleUsage, statePowerUp, info],
     ([$msToRent, $sampleUsage, $statePowerUp, $info]) => {
         if ($msToRent && $sampleUsage && $statePowerUp) {
@@ -109,18 +110,49 @@ export const powerupPrice = derived(
     }
 )
 
-export const stakingPrice = derived(
+// price per kb
+export const netPowerupPrice = derived(
+    [msToRent, sampleUsage, statePowerUp, info],
+    ([$msToRent, $sampleUsage, $statePowerUp, $info]) => {
+        if ($msToRent && $sampleUsage && $statePowerUp) {
+            const price = $statePowerUp.net.price_per_kb($sampleUsage, $msToRent, $info)
+            return Asset.from(
+                $statePowerUp.net.price_per_kb($sampleUsage, $msToRent, $info),
+                '4,EOS'
+            )
+        }
+        return Asset.from(0, '4,EOS')
+    }
+)
+
+//price per ms
+export const cpuStakingPrice = derived(
     [activeBlockchain, msToRent, sampleUsage],
     ([$activeBlockchain, $msToRent, $sampleUsage]) => {
         if ($msToRent && $sampleUsage) {
-            const {account} = $sampleUsage
+            const { account } = $sampleUsage
             const cpu_weight = Number(account.total_resources.cpu_weight.units)
             const cpu_limit = Number(account.cpu_limit.max.value)
             let price = cpu_weight / cpu_limit
             if ($activeBlockchain.resourceSampleMilliseconds) {
                 price *= $activeBlockchain.resourceSampleMilliseconds
             }
-            return Asset.fromUnits(price, $activeBlockchain.coreTokenSymbol)
+            return Asset.fromUnits(price * 1000, $activeBlockchain.coreTokenSymbol)
+        }
+        return Asset.from(0, $activeBlockchain.coreTokenSymbol)
+    }
+)
+
+// price per kb
+export const netStakingPrice = derived(
+    [activeBlockchain, msToRent, sampleUsage],
+    ([$activeBlockchain, $msToRent, $sampleUsage]) => {
+        if ($msToRent && $sampleUsage) {
+            const { account } = $sampleUsage
+            const net_weight = Number(account.total_resources.net_weight.units)
+            const net_limit = Number(account.net_limit.max.value)
+            let price = net_weight / net_limit
+            return Asset.fromUnits(price * 1000, $activeBlockchain.coreTokenSymbol)
         }
         return Asset.from(0, $activeBlockchain.coreTokenSymbol)
     }

--- a/src/pages/resources/resources.ts
+++ b/src/pages/resources/resources.ts
@@ -1,15 +1,22 @@
-import { derived, Readable } from 'svelte/store'
-import { Int64, API, Asset } from '@greymass/eosio'
-import { Resources, SampleUsage, PowerUpState, RAMState, REXState } from '@greymass/eosio-resources'
-import { activeBlockchain } from '~/store'
-import { BNPrecision } from '@greymass/eosio-resources'
+import {derived, Readable} from 'svelte/store'
+import {API, Asset} from '@greymass/eosio'
+import {
+    Resources,
+    SampleUsage,
+    PowerUpState,
+    RAMState,
+    REXState,
+    BNPrecision,
+} from '@greymass/eosio-resources'
 
-import { getClient } from '../../api-client'
-import { ChainConfig, ChainFeatures, resourceFeatures } from '~/config'
+import {activeBlockchain} from '~/store'
+
+import {getClient} from '../../api-client'
+import {ChainConfig, ChainFeatures, resourceFeatures} from '~/config'
 
 const getResourceClient = (chain: ChainConfig) => {
     const api = getClient(chain)
-    const options: any = { api }
+    const options: any = {api}
     if (chain.resourceSampleAccount) {
         options.sampleAccount = chain.resourceSampleAccount
     }
@@ -113,7 +120,7 @@ export const cpuPowerupPrice = derived(
 
 // price per kb
 export const netPowerupPrice = derived(
-    [activeBlockchain,sampleUsage, statePowerUp, info],
+    [activeBlockchain, sampleUsage, statePowerUp, info],
     ([$activeBlockchain, $sampleUsage, $statePowerUp, $info]) => {
         if ($sampleUsage && $statePowerUp) {
             return Asset.from(
@@ -130,7 +137,7 @@ export const cpuStakingPrice = derived(
     [activeBlockchain, msToRent, sampleUsage],
     ([$activeBlockchain, $msToRent, $sampleUsage]) => {
         if ($msToRent && $sampleUsage) {
-            const { account } = $sampleUsage
+            const {account} = $sampleUsage
             const cpu_weight = Number(account.total_resources.cpu_weight.units)
             const cpu_limit = Number(account.cpu_limit.max.value)
             let price = (cpu_weight / cpu_limit) * $msToRent
@@ -145,7 +152,7 @@ export const netStakingPrice = derived(
     [activeBlockchain, sampleUsage],
     ([$activeBlockchain, $sampleUsage]) => {
         if ($sampleUsage) {
-            const { account } = $sampleUsage
+            const {account} = $sampleUsage
             const net_weight = Number(account.total_resources.net_weight.units)
             const net_limit = Number(account.net_limit.max.value)
             let price = net_weight / net_limit
@@ -185,7 +192,7 @@ export const cpuRexPrice = derived(
     [activeBlockchain, msToRent, sampleUsage, stateREX],
     ([$activeBlockchain, $msToRent, $sampleUsage, $stateREX]) => {
         if ($msToRent && $sampleUsage && $stateREX) {
-            const price = $stateREX.price_per($sampleUsage, $msToRent * 30000);
+            const price = $stateREX.price_per($sampleUsage, $msToRent * 30000)
             const coreTokenSymbol = $activeBlockchain.coreTokenSymbol
             return compatPriceWithPrecision(price, coreTokenSymbol)
         }
@@ -206,9 +213,9 @@ export const netRexPrice = derived(
     }
 )
 
-function compatPriceWithPrecision(price : number, coreTokenSymbol : Asset.Symbol){
-    let precision = coreTokenSymbol.precision;
-    if (price > 0 && price < 1/Math.pow(10, precision)) {
+function compatPriceWithPrecision(price: number, coreTokenSymbol: Asset.Symbol) {
+    let precision = coreTokenSymbol.precision
+    if (price > 0 && price < 1 / Math.pow(10, precision)) {
         precision = Number(price.toExponential().split('-')[1])
     }
     return Asset.from(price, `${precision},${coreTokenSymbol.name}`)


### PR DESCRIPTION
1. add net powerup price、rex price、staking price
    case1: powerup rent, 0.0001 EOS per kb
            ======Base
            Available:102981.54 kb
            Used:0.00 kb
            Maximum:102981.54 kb
            ====After Rent 1000KB for 0.1000 EOS
            Available: 103981.54 kb
            Used: 0.00 kb
            Maximum: 103981.54 kb

     case2: rex rent, 0.00004 EOS per kb
             ======Base
             Available: 103981.54 kb
             Used:0.00 kb
             Maximum:103981.54 kb
             ======After Rent 100KB for 0.0040 EOS
             Available:106955.54 kb
             Used:0.00 kb
             Maximum:106955.54 kb 

     case3: staking rent, 0.0528 EOS per kb
             ======Base
              Available:106955.54 kb
              Used:0.00 kb
              Maximum:106955.54 kb 
              ======After: rent 0.0528 EOS
             Available:106956.54 kb
             Used:0.00 kb
             Maximum:106956.54 kb

2. calculate stakingprice in kb or ms,  avoid the situation where the asset value is 0 in smaller units